### PR TITLE
Bump html pipeline to 2.0

### DIFF
--- a/lib/link-rewriter-filter.rb
+++ b/lib/link-rewriter-filter.rb
@@ -1,7 +1,6 @@
 require 'html/pipeline'
 
 class LinkRewriterFilter < HTML::Pipeline::MarkdownFilter
-  VERSION = '0.0.1'
   LINK_REGEX = /(.+?)\.md$/
 
   def initialize(text, context = nil, result = nil)

--- a/link-rewriter-filter.gemspec
+++ b/link-rewriter-filter.gemspec
@@ -1,7 +1,4 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'link-rewriter-filter'
 
 Gem::Specification.new do |spec|
   spec.name          = "link-rewriter-filter"

--- a/link-rewriter-filter.gemspec
+++ b/link-rewriter-filter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'html-pipeline', "~> 2.0"
   spec.add_dependency 'github-markdown', "~> 0.6"
 
-  spec.add_development_dependency "bundler", "~> 1.9"
+  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'nokogiri', '~> 1.6'

--- a/link-rewriter-filter.gemspec
+++ b/link-rewriter-filter.gemspec
@@ -5,7 +5,7 @@ require 'link-rewriter-filter'
 
 Gem::Specification.new do |spec|
   spec.name          = "link-rewriter-filter"
-  spec.version       = LinkRewriterFilter::VERSION
+  spec.version       = '0.0.1'
   spec.authors       = ["Garen Torikian"]
   spec.email         = ["gjtorikian@gmail.com"]
 

--- a/link-rewriter-filter.gemspec
+++ b/link-rewriter-filter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'html-pipeline', "~> 1.0"
+  spec.add_dependency 'html-pipeline', "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/link-rewriter-filter.gemspec
+++ b/link-rewriter-filter.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'html-pipeline', "~> 2.0"
+  spec.add_dependency 'github-markdown', "~> 0.6"
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
In addition to https://github.com/gjtorikian/jekyll-html-pipeline/pull/7, this makes link-rewrite-filter compatible with the Jekyll 3 Gems, which depend on HTML Pipeline ~> 2.0,
