### PR TITLE
Drop reliance on MarkdownFilter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 2.1
-- 2.0.0
-- 1.9.3
+  - 2.0
+  - 2.1
+  - 2.2
 before_script: bundle update
 script: script/cibuild
+git:
+  depth: 10

--- a/lib/link-rewriter-filter.rb
+++ b/lib/link-rewriter-filter.rb
@@ -1,23 +1,15 @@
 require 'html/pipeline'
 
-class LinkRewriterFilter < HTML::Pipeline::MarkdownFilter
+class LinkRewriterFilter < HTML::Pipeline::Filter
   LINK_REGEX = /(.+?)\.md$/
 
-  def initialize(text, context = nil, result = nil)
-    @prefix = context[:link_rewriter_prefix] || '/docs/'
-
-    super text, context, result
-  end
-
   def call
-    html = super
-    doc = Nokogiri::HTML(html)
-
-    doc.search("a").each do |a|
-      next if a['href'].nil?
-      a["href"] = "#{@prefix}#{$1}/" if a['href'] =~ LINK_REGEX
+    prefix = context[:link_rewriter_prefix] || '/docs/'
+    doc.search('a').each do |a|
+      next if a['href'].nil? || a['href'].blank?
+      a['href'] = "#{prefix}#{$1}/" if a['href'] =~ LINK_REGEX
     end
 
-    doc.to_s
+    doc
   end
 end

--- a/link-rewriter-filter.gemspec
+++ b/link-rewriter-filter.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'html-pipeline', "~> 2.0"
-  spec.add_dependency 'github-markdown', "~> 0.6"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/link-rewriter-filter_spec.rb
+++ b/spec/link-rewriter-filter_spec.rb
@@ -3,12 +3,18 @@ require 'spec_helper'
 describe LinkRewriterFilter do
 
   it 'rewrites links without context' do
-    doc = LinkRewriterFilter.to_document(fixture('index.md'), {})
+    filter = LinkRewriterFilter.new \
+      "<a href='_docs/foo.md'>this page</a>"
+
+    doc = filter.call
     expect(doc.css('a').first.attr('href')).to eq('/docs/_docs/foo/')
   end
 
   it 'rewrites links with context' do
-    doc = LinkRewriterFilter.to_document(fixture('index.md'), { :link_rewriter_prefix => '/baz/' })
+    filter = LinkRewriterFilter.new \
+      "<a href='_docs/foo.md'>this page</a>", { :link_rewriter_prefix => '/baz/' }
+
+    doc = filter.call
     expect(doc.css('a').first.attr('href')).to eq('/baz/_docs/foo/')
   end
 end


### PR DESCRIPTION
Relying on the Markdown filter was dumb move on my part. Instead, this filter should simply be placed after the content becomes HTML. For example:

``` yaml
  filters:
    - markdownfilter
    - LinkRewriterFilter
    - TableOfContentsFilter
```

/cc @benbalter 
